### PR TITLE
First Iteration, NegaMax with alpha-beta pruning

### DIFF
--- a/Chess-Challenge/src/My Bot/MyBot.cs
+++ b/Chess-Challenge/src/My Bot/MyBot.cs
@@ -1,10 +1,106 @@
 ﻿using ChessChallenge.API;
+using System;
+using System.Collections.Generic;
 
 public class MyBot : IChessBot
 {
+
+    struct StateInfo
+    {
+        public float score;
+        public Move move;
+        public float examined_depth;
+        public StateInfo(float s, Move m, float depth)
+        {
+            score = s;
+            move = m;
+            examined_depth = depth;
+        }
+    }
+    private Dictionary<ulong, StateInfo> Transpositions = new Dictionary<ulong, StateInfo>();
+
+
     public Move Think(Board board, Timer timer)
     {
-        Move[] moves = board.GetLegalMoves();
-        return moves[0];
+        //Can this be removed?
+        //I need to figure out how to analyze memory usage in VisualStudio
+        Transpositions.Clear();
+        
+
+        return negamax(board, 5, float.NegativeInfinity, float.PositiveInfinity).Item2;
+    }
+
+    public (float, Move) negamax(Board board, int depth, float alpha, float beta)
+    {
+        if(depth == 0)
+        {
+            return (evaluate(board), Move.NullMove);
+        }
+        if(board.IsInCheckmate() || board.IsDraw())
+        {
+            return (float.NegativeInfinity, Move.NullMove);
+        }
+
+        if(Transpositions.ContainsKey(board.ZobristKey))
+        {
+            StateInfo s = Transpositions[board.ZobristKey];
+            if(s.examined_depth >= depth)
+            {// This search is not going further than previous searches,
+             // we can return the previously computed score.
+                return (s.score, s.move);
+            }
+        }
+
+        float bestScore = float.NegativeInfinity;
+        Move bestMove = Move.NullMove;
+        foreach(Move move in board.GetLegalMoves())
+        {
+            board.MakeMove(move);
+            float score = -negamax(board, depth - 1, -beta, -alpha).Item1;
+            board.UndoMove(move);
+
+
+            if (score > bestScore)
+            {
+                bestScore = score;
+                bestMove = move;
+
+                alpha = Math.Max(bestScore, alpha);
+                if(alpha >= beta)
+                {
+                    break;
+                }
+            }
+
+            
+        }
+        if(bestMove == Move.NullMove)
+        {
+            bestMove = board.GetLegalMoves()[0];
+        }
+        if (Transpositions.ContainsKey(board.ZobristKey)) Transpositions.Remove(board.ZobristKey);
+        Transpositions.Add(board.ZobristKey, new StateInfo(bestScore, bestMove, depth));
+        
+        return (bestScore, bestMove);
+    }
+
+
+    public float evaluate(Board board)
+    {
+
+        float sum = 0;
+        if (board.IsInCheckmate())  // Check if the CURRENT player is in checkmate (NEGATIVE SCORE)
+        {
+            sum = float.NegativeInfinity;
+        }
+        int[] values = {0, 1, 3, 4, 5, 9 };
+        for(int i = 1; i < 5; i++)
+        {
+            sum += values[i] * BitboardHelper.GetNumberOfSetBits(board.GetPieceBitboard((PieceType)i, board.IsWhiteToMove));
+            sum += -values[i] * BitboardHelper.GetNumberOfSetBits(board.GetPieceBitboard((PieceType)i, !board.IsWhiteToMove));
+
+        }
+        return sum;
     }
 }
+


### PR DESCRIPTION
NegaMax is used along with alpha-beta pruning to search for the best performing sequence of moves, based on the evaluation function.

The evaluation function is a simple one that compares the total value of a player's pieces to their opponent's. It does not take into account piece positioning.

A transposition table is used to store previously computed board states and speed up the search algorithm.

This outperforms EvilBot in most cases, while sometimes drawing due to repetition.

Useful Links:
https://www.chessprogramming.org/Negamax
https://www.chessprogramming.org/Transposition_Table https://www.chessprogramming.org/Alpha-Beta